### PR TITLE
Some optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *__pycache__*
 .cache/*
 .idea/*
+.venv/
 .pytest_cache/*
 htmlcov/*
 .coverage
-

--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,10 @@
+[scripts]
+tests = "./test.sh"
+
 [requires]
 python_version = '3.6'
 
-[packages-dev]
+[dev-packages]
 pytest = "==3.10.1"
 pytest-cov = "==2.6.1"
 pytest-profiling = "==1.4.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "415dfdcb118dd9bdfef17671cb7dcd78dbd69b6ae7d4f39e8b44e71d60ca72e7"
+            "sha256": "27d53e718f6074e2f7007a83d3323c77f933efed816105ab2e9e2c2969355387"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,5 +16,129 @@
         ]
     },
     "default": {},
-    "develop": {}
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
+                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
+                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
+                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
+                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
+                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
+                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
+                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
+                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
+                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
+                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
+                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
+                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
+                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
+                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
+                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
+                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
+                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
+                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
+                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
+                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
+                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
+                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
+                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
+                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
+                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
+                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
+                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
+                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
+                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
+                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
+                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
+            ],
+            "version": "==4.5.4"
+        },
+        "gprof2dot": {
+            "hashes": [
+                "sha256:cebc7aa2782fd813ead415ea1fae3409524343485eadc7fb60ef5bd1e810309e"
+            ],
+            "version": "==2017.9.19"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
+                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+            ],
+            "version": "==0.19"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "version": "==7.2.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+            ],
+            "version": "==0.12.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec",
+                "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"
+            ],
+            "index": "pypi",
+            "version": "==3.10.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
+                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+            ],
+            "index": "pypi",
+            "version": "==2.6.1"
+        },
+        "pytest-profiling": {
+            "hashes": [
+                "sha256:437be67114009b40aac145bb135fcd9a4cf2cc6bbf8ccb3d2921894396e92640",
+                "sha256:f826859197a41f719a853b7e14ea0fd9b8f9de5515aad6827451f204813c0e4f"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+            ],
+            "version": "==0.5.2"
+        }
+    }
 }

--- a/replay_parser/body.py
+++ b/replay_parser/body.py
@@ -1,9 +1,9 @@
 import struct
-from typing import List, Dict, Any, Iterator, Tuple, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from replay_parser.commands import COMMAND_PARSERS
-from replay_parser.constants import CommandStates, CommandStateNames
-from replay_parser.reader import ReplayReader, ACCEPTABLE_DATA_TYPE
+from replay_parser.constants import CommandStateNames, CommandStates
+from replay_parser.reader import ACCEPTABLE_DATA_TYPE, ReplayReader
 
 __all__ = ('ReplayBody',)
 
@@ -91,7 +91,7 @@ class ReplayBody:
 
     def parse_command_and_get_data(self) -> Tuple[Optional[int], Optional[bytes]]:
         """
-        Parses one command and returns it type and binary data for whole command
+        Parses one command and returns its type and binary data for whole command
 
         Packet structure in bytestream
         ::
@@ -112,7 +112,7 @@ class ReplayBody:
         command_length_byte = self.replay_reader.read(2)
 
         command_type = struct.unpack("B", command_type_byte)[0]
-        command_length = struct.unpack("H", command_length_byte)[0]
+        command_length = struct.unpack("<H", command_length_byte)[0]
 
         data = self.replay_reader.read(command_length - 3)
 

--- a/replay_parser/reader.py
+++ b/replay_parser/reader.py
@@ -27,7 +27,7 @@ class ReplayReader:
         """
         Parses string from binary data.
         """
-        res = b""
+        res = bytearray()
         while True:
             char_ = unpack("s", self.buffer.read(1))[0]
             if char_ == b'\x00':

--- a/replay_parser/reader.py
+++ b/replay_parser/reader.py
@@ -37,13 +37,13 @@ class ReplayReader:
         """
         res = bytearray()
         while True:
-            char_ = unpack("s", self.buffer.read(1))[0]
+            char_ = unpack("c", self.buffer.read(1))[0]
             if char_ == b'\x00':
                 break
             res += char_
         return res.decode()
 
-    def read_number(self, type_: str = "i", size: int = 4) -> Union[int, float]:
+    def read_number(self, type_: str = "<i", size: int = 4) -> Union[int, float]:
         """
         Reads number/float/boolean by input type & size
         """
@@ -51,13 +51,13 @@ class ReplayReader:
         return value
 
     def read_int(self) -> int:
-        return self.read_number(type_="i", size=4)
+        return self.read_number(type_="<i", size=4)
 
     def read_short(self) -> int:
-        return self.read_number(type_="H", size=2)
+        return self.read_number(type_="<H", size=2)
 
     def read_float(self) -> float:
-        return self.read_number(type_="f", size=4)
+        return self.read_number(type_="<f", size=4)
 
     def read_byte(self) -> int:
         return self.read_number(type_="B", size=1)


### PR DESCRIPTION
Optimizations:
- Removed peek
- Use `bytearray` instead of `bytes` for reading strings

Compatibility:
- Specify endianness of number types explicitly (otherwise the default is to use the platform native endianness which would cause big endian machines to parse the replays incorrectly)

Pipenv
- Fixed Pipfile dev-packages section
- Added pipenv tests script for convenience

Other:
- sorted imports