### PR TITLE
Some more cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .pytest_cache/*
 htmlcov/*
 .coverage
+prof/

--- a/replay_parser/body.py
+++ b/replay_parser/body.py
@@ -15,14 +15,14 @@ class ReplayBody:
     def __init__(
             self,
             reader: ReplayReader,
-            parse_until_desync: bool = False,
+            stop_on_desync: bool = False,
             parse_commands: set = None,
             store_body: bool = False,
             **kwargs
     ) -> None:
         """
         :param ReplayReader reader: Handles basic operations on stream
-        :param bool parse_until_desync: stops parsing at first desync
+        :param bool stop_on_desync: stops parsing at first desync
         :param set parse_commands: set or list of commands ids to parse,
             list is defined in from `replay_parser.commands.COMMAND_PARSERS`.
             Important: you can't detect desyncs, if you won't have CommandStates.VerifyChecksum
@@ -44,7 +44,7 @@ class ReplayBody:
         self.previous_tick = -1
         self.previous_checksum = None
 
-        self.parse_until_desync = bool(parse_until_desync)
+        self.stop_on_desync = bool(stop_on_desync)
         self.parse_commands = set(parse_commands or set())
         self.store_body = bool(store_body)
 
@@ -57,7 +57,7 @@ class ReplayBody:
     def get_last_players_ticks(self) -> Dict:
         return self.last_players_tick
 
-    def get_desync_tics(self) -> List:
+    def get_desync_ticks(self) -> List:
         return self.desync_ticks
 
     def parse(self) -> None:
@@ -152,7 +152,7 @@ class ReplayBody:
         elif command_type == CommandStates.VerifyChecksum:
             checksum, tick = command_data["checksum"], command_data["tick"]
             if tick == self.previous_tick and checksum != self.previous_checksum:
-                if self.parse_until_desync:
+                if self.stop_on_desync:
                     raise StopIteration()
 
                 self.desync_ticks.append(self.tick)

--- a/replay_parser/replay.py
+++ b/replay_parser/replay.py
@@ -30,7 +30,7 @@ def parse(
         body_parser.parse()
         result["body"] = body_parser.get_body()
         result["messages"] = body_parser.get_messages()
-        result["desync_ticks"] = body_parser.get_desync_tics()
+        result["desync_ticks"] = body_parser.get_desync_ticks()
 
     return result
 

--- a/tests/unittests/replay.py
+++ b/tests/unittests/replay.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from constants import CommandStates
 from replay_parser.body import ReplayBody
 from replay_parser.reader import ReplayReader
-from replay_parser.replay import parse, continuous_parse
+from replay_parser.replay import continuous_parse, parse
 
 
 def test_replay_parse(replays, replay_file_name):
@@ -71,6 +71,5 @@ def test_continuous_parse_command_by_command(replays):
         assert times == 1
 
 
-def test_parse_until_desync(replays):
-    parse(replays, test_parse_until_desync=True)
-
+def test_stop_on_desync(replays):
+    parse(replays, stop_on_desync=True)


### PR DESCRIPTION
Changed some variable names which revealed a bug in the `stop_on_desync` test where the parameter wasn't being named correctly. Now it throws `DeprecationWarning`s saying that generators should not raise `StopIteration`.